### PR TITLE
3GPP stop-gap version

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,34 @@
+name: "Archive Issues and Pull Requests"
+
+on:
+  schedule:
+    - cron: '0 0 * * 0,2,4'
+  repository_dispatch:
+    types: [archive]
+
+jobs:
+  build:
+    name: "Archive Issues and Pull Requests"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    - name: "Update Archive"
+      uses: martinthomson/i-d-template@v1
+      with:
+        make: archive
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Update GitHub Pages"
+      uses: martinthomson/i-d-template@v1
+      with:
+        make: gh-archive
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Save Archive"
+      uses: actions/upload-artifact@v2
+      with:
+        path: archive.json

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -1,0 +1,60 @@
+name: "Update Editor's Copy"
+
+on:
+  push:
+    paths-ignore:
+    - README.md
+    - CONTRIBUTING.md
+    - LICENSE.md
+    - .gitignore
+  pull_request:
+    paths-ignore:
+    - README.md
+    - CONTRIBUTING.md
+    - LICENSE.md
+    - .gitignore
+
+jobs:
+  build:
+    name: "Update Editor's Copy"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    - name: "Cache Setup"
+      id: cache-setup
+      run: |
+        mkdir -p "$HOME"/.cache/xml2rfc
+        echo "::set-output name=path::$HOME/.cache/xml2rfc"
+        date -u "+::set-output name=date::%FT%T"
+
+    - name: "Cache References"
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.cache-setup.outputs.path }}
+        key: refcache-${{ steps.cache-setup.outputs.date }}
+        restore-keys: |
+          refcache-${{ steps.cache-setup.outputs.date }}
+          refcache-
+
+    - name: "Build Drafts"
+      uses: martinthomson/i-d-template@v1
+
+    - name: "Update GitHub Pages"
+      uses: martinthomson/i-d-template@v1
+      if: ${{ github.event_name == 'push' }}
+      with:
+        make: gh-pages
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Save HTML"
+      uses: actions/upload-artifact@v2
+      with:
+        path: "*.html"
+
+    - name: "Save Text"
+      uses: actions/upload-artifact@v2
+      with:
+        path: "*.txt"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: "Publish New Draft Version"
+
+on:
+  push:
+    tags:
+      - "draft-*"
+
+jobs:
+  build:
+    name: "Publish New Draft Version"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    # See https://github.com/actions/checkout/issues/290
+    - name: "Get Tag Annotations"
+      run: git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+
+    - name: "Cache Setup"
+      id: cache-setup
+      run: |
+        mkdir -p "$HOME"/.cache/xml2rfc
+        echo "::set-output name=path::$HOME/.cache/xml2rfc"
+        date -u "+::set-output name=date::%FT%T"
+
+    - name: "Cache References"
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.cache-setup.outputs.path }}
+        key: refcache-${{ steps.date.outputs.date }}
+        restore-keys: |
+          refcache-${{ steps.date.outputs.date }}
+          refcache-
+
+    - name: "Upload to Datatracker"
+      uses: martinthomson/i-d-template@v1
+      with:
+        make: upload

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.Guardfile
-.config.ru
 *.html
 *.pdf
 *.redxml
@@ -7,11 +5,15 @@
 *.txt
 *.upload
 *~
+.Guardfile
+.config.ru
 .refcache
 .tags
 .targets.mk
 /*-[0-9][0-9].xml
 archive.json
+draft-ietf-core-problem-details.xml
+lib
 report.xml
 venv/
 lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.Guardfile
+.config.ru
 *.html
 *.pdf
 *.redxml

--- a/.note.xml
+++ b/.note.xml
@@ -1,4 +1,7 @@
 <note title="Discussion Venues" removeInRFC="true">
+<t>Discussion of this document takes place on the
+  CORE Working Group mailing list (core@ietf.org),
+  which is archived at <eref target="https://mailarchive.ietf.org/arch/browse/core/"/>.</t>
 <t>Source for this draft and an issue tracker can be found at
-  <eref target="https://github.com/core-wg/core-problem-details">https://github.com/core-wg/core-problem-details</eref>.</t>
+  <eref target="https://github.com/core-wg/core-problem-details"/>.</t>
 </note>

--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ ifneq (,$(shell grep "path *= *$(LIBDIR)" .gitmodules 2>/dev/null))
 	git submodule update $(CLONE_ARGS) --init
 else
 	git clone -q --depth 10 $(CLONE_ARGS) \
-	    -b master https://github.com/martinthomson/i-d-template $(LIBDIR)
+	    -b main https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Problem Details For CoAP APIs
+# Concise Problem Details For CoAP APIs
 
-This is the working area for the IETF [CORE Working Group](https://datatracker.ietf.org/wg/core/documents/) Internet-Draft, "Problem Details For CoAP APIs".
+This is the working area for the IETF [CORE Working Group](https://datatracker.ietf.org/wg/core/documents/) Internet-Draft, "Concise Problem Details For CoAP APIs".
 
 * [Editor's Copy](https://core-wg.github.io/core-problem-details/#go.draft-ietf-core-problem-details.html)
 * [Working Group Draft](https://tools.ietf.org/html/draft-ietf-core-problem-details)

--- a/draft-ietf-core-problem-details.md
+++ b/draft-ietf-core-problem-details.md
@@ -1,8 +1,12 @@
 ---
+v: 3
+
 title: Problem Details For CoAP APIs
 abbrev: CoRE Problem Details
 docname: draft-ietf-core-problem-details-latest
 category: std
+consensus: true
+submissiontype: IETF
 
 ipr: trust200902
 area: ART
@@ -13,224 +17,297 @@ stand_alone: yes
 pi: [toc, sortrefs, symrefs]
 
 author:
- -
-    ins: "T. Fossati"
-    name: "Thomas Fossati"
+ -  name: "Thomas Fossati"
     organization: "arm"
     email: thomas.fossati@arm.com
- -
-    ins: "J. Jiménez"
-    name: "Jaime Jiménez"
-    organization: "Ericsson"
-    email: jaime@iki.fi
+ -  name: Carsten Bormann
+    org: Universität Bremen TZI
+    orgascii: Universitaet Bremen TZI
+    street: Postfach 330440
+    city: Bremen
+    code: D-28359
+    country: Germany
+    phone: +49-421-218-63921
+    email: cabo@tzi.org
 
- -
-    ins: "K. Hartke"
-    name: "Klaus Hartke"
-    organization: "Ericsson"
-    email: klaus.hartke@ericsson.com
+normative:
+  STD94:
+    -: bis
+    =: RFC8949
+  RFC7252: coap
+  RFC7807:
 
 --- abstract
 
-This document defines a "problem detail" as a way to carry machine-readable details of errors in a CoAP response to avoid the need to define new error response formats for CoAP APIs.  The proposed format is inspired by the Problem Details for HTTP APIs defined in RFC 7807.
+This document defines a "problem detail" as a way to carry
+machine-readable details of errors in a REST response to avoid the
+need to define new error response formats for REST APIs.
+The format
+is inspired by, but intended to be more concise than, the Problem
+Details for HTTP APIs defined in RFC 7807.
 
 --- middle
 
 # Introduction
 
-CoAP {{!RFC7252}} response codes are sometimes not sufficient to convey enough information about an error to be helpful.  This specification defines a simple and extensible CoRAL {{!I-D.ietf-core-coral}} vocabulary to suit this purpose.  It is designed to be reused by CoAP APIs, which can identify distinct "problem types" specific to their needs.  Thus, API clients can be informed of both the high-level error class (using the response code) and the finer-grained details of the problem (using this vocabulary), as shown in {{fig-problem-details}}.
+REST response status information such as CoAP {{-coap}} response
+codes is sometimes not sufficient to convey enough information about
+an error to be helpful.  This specification defines a simple and
+extensible framework to define CBOR tags to suit this purpose.
+It is designed to be reused by REST APIs, which can identify distinct
+"problem types" specific to their needs.
+Thus, API clients can be informed of both the high-level error class
+(using the response code) and the finer-grained details of the problem
+(using this vocabulary), as shown in {{fig-problem-details}}.
 
+~~~ aasvg
++--------+           +--------+
+|  CoAP  |           |  CoAP  |
+| Client |           | Server |
++----+---+           +----+---+
+     |                    |
+     | Request            |
+     |------------------> |
+     |                    |
+     | <----------------- |
+     | Error Response     |
+     | with a CBOR Data   |
+     | Item giving        |
+     | Problem Details    |
+     |                    |
 ~~~
-{::include problem-details.ascii-art}
-~~~
-{: #fig-problem-details artwork-align="center" title="Problem Details"}
+{: #fig-problem-details artwork-align="center"
+   title="Problem Details: Example with CoAP"}
 
-The vocabulary presented is largely inspired by the Problem Details for HTTP APIs defined in {{?RFC7807}}.
+The framework presented is largely inspired by the Problem Details for HTTP APIs defined in {{RFC7807}}.
 
 ## Requirements Language
 
-{::boilerplate bcp14}
+{::boilerplate bcp14-tagged}
 
 # Basic Problem Details
 
-A CoRE Problem Details is a CoRAL document with the following elements:
+A Concise Problem Details data item is a CBOR data item with the following
+structure (notated in CDDL {{!RFC8610}}, using 65535 in place of a tag number to
+be defined for the type of problem details):
 
-* "type" (id) - The problem type.  This is a mandatory element.
-* "title" (text) - A short, human-readable summary of the problem type.  It SHOULD NOT change from occurrence to occurrence of the problem.
-* "detail" (text) - A human-readable explanation specific to this occurrence of the problem.
-* "instance" (uri) - A URI reference that identifies the specific occurrence of the problem.  It may or may not yield further information if dereferenced.
+~~~ CDDL
+problem-details = #6.65535(problem-details-map)
+problem-details-map = {
+  ? &(title: -1) => text
+  ? &(detail: -2) => text
+  ? &(instance: -3) => ~uri
+  standard-problem-detail-entries
+  custom-problem-detail-entries
+}
+standard-problem-detail-entries = (
+  * nint => any
+)
+custom-problem-detail-entries = (
+  * (uint/detail-label) => any
+)
+detail-label = text .regexp "[^:]+" / ~uri
+~~~
+{: #cddl title="Problem Detail Data Item"}
 
-Consumers MUST use "type" as primary identifiers for the problem type; the "title" string is advisory and included only for consumers who are not aware of the semantics of the "type" value.  An initial set of "type"s and corresponding "title"s is defined in {{sec-response-code-types}}.
+The problem type is expressed in the tag number shown here as 65535.
+A tag has been registered as a generic problem type (see {{iana-tag}}),
+further tags for problem types can be registered (see {{sec-new-attributes}}).
+
+A number of problem details are predefined (more predefined details
+can be registered, see {{iana-spdk}}):
+
+{:vspace}
+The title (key -1):
+: A short, human-readable summary of the problem type.  It SHOULD NOT change from occurrence to occurrence of the problem.
+
+The detail (key -2):
+: A human-readable explanation specific to this occurrence of the problem.
+
+The instance (key -3):
+: A URI reference that identifies the specific occurrence of the problem.  It may or may not yield further information if dereferenced.
+
+Consumers MUST use the type (tag number) as primary identifiers for the problem type; the "title" string is advisory and included only for consumers who are not aware of the semantics of the "type" value.
 
 The "detail" member, if present, ought to focus on helping the client correct the problem, rather than giving debugging information.  Consumers SHOULD NOT parse the "detail" member for information; extensions (see {{sec-new-attributes}}) are more suitable and less error-prone ways to obtain such information.
 
-Note that the "instance" URI reference may be relative; this means that it must be resolved relative to the document's base URI, as per {{!I-D.ietf-core-coral}}.
-
-## Examples
-{: #sec-coral-examples}
-
-This section presents a series of examples of the basic vocabulary in CoRAL textual format (Section 4 of {{!I-D.ietf-core-coral}}).  The examples are fictitious.  No identification with actual products is intended or should be inferred.  All examples involve the same CoAP problem type with semantics of "unknown key id", defined in the fictitious namespace `http://vocabulary.private-api.example`.
-
-Note that CoRAL documents are exchanged in CoRAL binary format (Section 3 of {{!I-D.ietf-core-coral}}) in practice. This includes the use of {{?I-D.ietf-core-href}} as an alternative to URIs that is optimized for constrained nodes.
-
-The example in {{fig-example-minimalist}} has the most compact representation.  It avoids any non-mandatory element.  This is suitable for a constrained receiver that happens to have precise knowledge of the semantics associated with the "type".
-
-~~~
-#using pd = <http://example.org/vocabulary/problem-details#>
-#using ex = <http://vocabulary.private-api.example/#>
-
-pd:type         ex:unknown-key-id
-~~~
-{: #fig-example-minimalist title="Minimalist"}
-
-The example in {{fig-example-full-fledged}} has all the mandatory as well as the optional elements populated.  This format is appropriate for a less constrained receiver (for example, an edge gateway forwarding to a log server that needs to gather as much contextual information as possible, including the problem "headline", details about the error condition, and an error-specific instance URL).
-
-~~~
-#using pd = <http://example.org/vocabulary/problem-details#>
-#using ex = <http://vocabulary.private-api.example/#>
-
-pd:type         ex:unknown-key-id
-pd:title        "unknown key id"
-pd:detail       "Key with id 0x01020304 not registered"
-pd:instance     <https://private-api.example/errors/5>
-~~~
-{: #fig-example-full-fledged title="Full-Fledged"}
-
-# Response Code Problem Detail Types
-{: #sec-response-code-types }
-
-This document defines an initial set of Problem Detail types that match the
-corresponding CoAP response codes in the 4.xx (client error) and 5.xx (server
-error) space.  See {{tbl-response-code-types}}.
-
-When using one such problem type, an application MUST make sure that the type
-matches the CoAP response code in the underlying CoAP transaction.
-
-If a title element is used in the Problem Details payload, it SHOULD be
-populated with the title corresponding to the type.
-
-The types defined in this document reflect the state of the relevant portion of
-the "CoAP Codes" registry at the time of writing.
-
-| Type | Title |
-| --- | ----------- |
-| pd:4.00 | "Bad Request" |
-| pd:4.01 | "Unauthorized" |
-| pd:4.02 | "Bad Option" |
-| pd:4.03 | "Forbidden" |
-| pd:4.04 | "Not Found" |
-| pd:4.05 | "Method Not Allowed" |
-| pd:4.06 | "Not Acceptable" |
-| pd:4.08 | "Request Entity Incomplete" |
-| pd:4.09 | "Conflict" |
-| pd:4.12 | "Precondition Failed" |
-| pd:4.13 | "Request Entity Too Large" |
-| pd:4.15 | "Unsupported Content-Format" |
-| pd:4.22 | "Unprocessable Entity" |
-| pd:4.29 | "Too Many Requests" |
-| pd:5.00 | "Internal Server Error" |
-| pd:5.01 | "Not Implemented" |
-| pd:5.02 | "Bad Gateway" |
-| pd:5.03 | "Service Unavailable" |
-| pd:5.04 | "Gateway Timeout" |
-| pd:5.05 | "Proxying Not Supported" |
-| pd:5.08 | "Hop Limit Reached" |
-{: #tbl-response-code-types }
-
-# Additional Features
-
-In the following sections we introduce specific (albeit "common enough") use
-cases, and define the extensions to the basic format needed to support them.
-
-## Tracing and Extended Diagnostic
-
-Consumers of Problem Details might be located at the far end of a logging and
-analytics pipeline.  For example, this might be the case when a CoAP server or
-CoAP API gateway is located in an edge gateway node and forwards its logs to a
-cloud collector, which in turn aggregates a potentially huge number of
-different servers and transactions (see {{fig-log-pipeline}}).
-
-~~~
-{::include log-pipeline.ascii-art}
-~~~
-{: #fig-log-pipeline title="Logging Pipeline"}
-
-It is quite common in a situation like the above that an already deployed
-server is temporarily put in "tracing mode" to diagnose a failure.  In this
-case having a separate channel for the tracing info provides a superior
-solution (in terms of ease of ingesting and processing) to overloading the
-`detail` field and having to write ad-hoc filtering logics to extract the
-relevant information from it.  Cost-wise, the producer would not incur any
-added overhead while, from the transport perspective, the slight increase in
-bandwidth to support the extra structuring is typically dwarfed by the
-(verbose) content of the diagnostic payload.  The same mechanism would also be
-useful during the development and test of a new application, giving the
-developer insight into the internal state of the application.
-
-The additional protocol element is:
-
-* "diag" (text) - a string.  It may contain anything of user's choice: extra
-  information complementing the what already present in `detail`, a stack
-  trace, a distributed trace span ending in an error condition, etc.
-
-Leaking private or sensitive data SHOULD be avoided.
-
-### Examples
-
-The example in {{fig-example-diag-stack}} has a `diag` element with a stack
-trace associated with the error condition.
-
-~~~
-#using pd = <http://example.org/vocabulary/problem-details#>
-
-pd:type         pd:5.00
-pd:title        "Internal Server Error"
-pd:detail       "handler exception"
-pd:instance     <https://private-api.example/errors/2>
-pd:diag         "File \"example.py\", line 7, in \<module\>\n
-                 caller()\nFile \"example.py\", line 5, in caller\n
-                 callee()\nFile \"example.py\", line 2, in callee\n
-                 raise Exception(\"Yikes\")\n"
-~~~
-{: #fig-example-diag-stack title="Diagnostic message containing a stack trace"}
+Note that the "instance" URI reference may be relative; this means that it must be resolved relative to the document's base URI, as per {{!RFC3986}}.
 
 # Additional Problem Details
 {: #sec-new-attributes}
 
-Problem type definitions MAY extend the Problem Details document with additional elements to convey additional, problem-specific information.
+To establish a custom problem type, A CBOR Tag number needs to be
+registered in the {{cbor-tags (CBOR Tags)<IANA.cbor-tags}} of {{!IANA.cbor-tags}}.
+Note that this registry allows the registration of new tags under the
+First Come First Served policy {{?RFC8126}}, making new registrations
+available in a simple interaction (e.g., via web or email) with IANA,
+having filled in the small template provided in {{Section 9.2 of
+STD94}}.
 
-Clients consuming problem details MUST ignore any such elements that they do not recognize; this allows problem types to evolve and include additional information in the future.
+Problem type definitions MAY extend the Problem Details document with
+additional entries to convey additional, problem-specific information.
+These receive a custom problem detail entry map key (unsigned integer
+or text)
+and SHOULD be described in a specification that goes along with such a
+registration.  Such a specification SHOULD also reference the present
+specification.
+For text detail-labels, a name without an embedded colon can be chosen
+instead of an integer custom label, or a detail-label that is a URI.
+This URI is for identification purposes only and MUST NOT be
+dereferenced in the normal course of handling problem details (i.e.,
+outside diagnostic/debugging procedures involving humans).
 
-## Examples
+Beyond the Standard Problem Detail keys defined in {{cddl}}, additional
+Standard Problem Detail keys can be registered (see {{iana-spdk}}).
+This is intended to be use for problem details that cover an area of
+application that includes multiple registered problem types.
 
-The example in {{fig-example-ext-full}} has all the basic elements as well as an additional, type-specific element.
+Clients consuming problem details may be able to consume unknown
+Problem types (i.e., with unknown CBOR Tag numbers), if the general
+context (e.g., a media type known from the context such as that
+defined in {{media-type}}) indicates that the present specification is used.
+Such consumers MUST ignore any entries that they do not recognize;
+this allows problem types to evolve and include additional information in the future.
 
-~~~
-#using pd = <http://example.org/vocabulary/problem-details#>
-#using ex = <http://vocabulary.private-api.example/#>
+# Security Considerations {#seccons}
 
-pd:type         ex:unknown-key-id
-pd:title        "unknown key id"
-pd:detail       "Key with id 0x01020304 not registered"
-pd:instance     <https://private-api.example/errors/5>
-ex:key-id       0x01020304
-~~~
-{: #fig-example-ext-full title="Full Payload and Extensions"}
-
-# Security Considerations
-
-Problem Details for CoAP APIs are serialized in the CoRAL binary format.  See Section 11 of {{!RFC7252}}  for security considerations relating to CoAP.  See Section 7 of {{!I-D.ietf-core-coral}} for security considerations relating to
-CoRAL.
-
-The security and privacy considerations outlined in Section 5 of {{?RFC7807}} apply in full.
+The security and privacy considerations outlined in Section 5 of {{RFC7807}} apply in full.
 
 # IANA Considerations
 
-TODO.
+[^to-be-removed]
+
+[^to-be-removed]: RFC Editor: please replace RFC XXXX with this RFC number and remove this note.
+
+## CBOR Tag {#iana-tag}
+
+As per {{STD94}}, IANA has created a "{{cbor-tags (CBOR
+Tags)<IANA.cbor-tags}}" registry {{IANA.cbor-tags}},
+which serves as the registry for problem details types (see {{sec-new-attributes}}).
+For use as a predefined, generic problem details type,
+IANA is requested to allocate the tag defined in {{tab-tag-values}}.
+
+| Tag    | Data Item | Semantics               | Reference |
+| TBD400 | map       | Generic Problem Details | RFCXXXX   |
+{: #tab-tag-values align='left'  title="Generic Problem Details tag"}
+
+## Standard Problem Detail Key registry {#iana-spdk}
+
+<!-- {{content-formats (CoAP Content-Formats)<IANA.core-parameters}} -->
+
+This specification defines a new sub-registry for Standard Problem
+Detail Keys in the CoRE Parameters registry {{!IANA.core-parameters}}),
+with the policy "specification required" {{!RFC8126}}.
+
+Each entry in the registry must include:
+
+{:vspace}
+key value:
+: a negative integer to be used as the value of the key
+
+name:
+: a name that could be used in implementations for the key
+
+type:
+: type of the data associated with the key; preferably in CDDL
+  notation
+
+brief description:
+: a brief description
+
+reference:
+: a reference document
+
+Initial entries in this sub-registry are as follows:
+
+| Key value | Name     | Type | Brief Description                                                     | Reference |
+|        -1 | title    | text | short, human-readable summary of the problem type                     | RFCXXXX   |
+|        -2 | detail   | text | human-readable explanation specific to this occurrence of the problem | RFCXXXX   |
+|        -3 | instance | ~uri | URI reference identifying specific occurrence of the problem          | RFCXXXX   |
+{: #spdk title="Initial Entries in Standard Problem Detail Key registry"}
+
+## Media Type
+
+IANA is requested to add the following Media-Type to the "Media Types" registry.
+
+| Name                         | Template                                 | Reference              |
+| concise-problem-details+cbor | application/concise-problem-details+cbor | RFC XXXX, {{media-type}} |
+{: #new-media-type align="left" title="New Media Type application/concise-problem-details+cbor"}
+
+{:compact}
+Type name:
+: application
+
+Subtype name:
+: concise-problem-details+cbor
+
+Required parameters:
+: none
+
+Optional parameters:
+: none
+
+Encoding considerations:
+: binary (CBOR data item)
+
+Security considerations:
+: {{seccons}} of RFC XXXX
+
+Interoperability considerations:
+: none
+
+Published specification:
+: {{media-type}} of RFC XXXX
+
+Applications that use this media type:
+: Clients and servers in the Internet of Things
+
+Fragment identifier considerations:
+: The syntax and semantics of fragment identifiers is as specified for
+  "application/cbor".  (At publication of RFC XXXX, there is no
+  fragment identification syntax defined for "application/cbor".)
+
+Person & email address to contact for further information:
+: CoRE WG mailing list (core@ietf.org),
+  or IETF Applications and Real-Time Area (art@ietf.org)
+
+Intended usage:
+: COMMON
+
+Restrictions on usage:
+: none
+
+Author/Change controller:
+: IETF
+
+Provisional registration:
+: no
+
+## Content-Format
+
+IANA is requested to register a Content-Format number in the
+{{content-formats ("CoAP Content-Formats")<IANA.cbor-tags}}
+sub-registry, within the "Constrained RESTful Environments (CoRE)
+Parameters" Registry {{IANA.core-parameters}}, as follows:
+
+{{content-formats ("CoAP Content-Formats")<IANA.cbor-tags}} 
+
+| Content-Type                             | Content Coding | ID   | Reference |
+| application/concise-problem-details+cbor | -              | TBD1 | RFC XXXX  |
+{: align="left" title="New Content-Format"}
+
+TBD1 is to be assigned from the space 256..999.
+
+In the registry as defined by {{Section 12.3 of -coap}} at the time of
+writing, the column "Content-Type" is called "Media type" and the
+column "Content Coding" is called "Encoding".
 
 --- back
 
 # Acknowledgments
-{: numbered="no"}
+{:unnumbered}
 
-Mark Nottingham and Erik Wilde, authors of RFC 7807.  Carsten Bormann, Jim Schaad, Christian Amsüss for review and comments on this document.
+{{{Mark Nottingham}}} and {{{Erik Wilde}}}, authors of RFC 7807.
+{{{Klaus Hartke}}} and {{{Jaime Jiménez}}}, co-authors of an earlier generation of
+this specification.
+{{{Christian Amsüss}}} for review and comments on this document.

--- a/draft-ietf-core-problem-details.md
+++ b/draft-ietf-core-problem-details.md
@@ -93,13 +93,13 @@ be defined for the type of problem details):
 
 ~~~ CDDL
 problem-details = #6.65535(problem-details-map)
-problem-details-map = {
+problem-details-map = non-empty<{
   ? &(title: -1) => text
   ? &(detail: -2) => text
   ? &(instance: -3) => ~uri
   standard-problem-detail-entries
   custom-problem-detail-entries
-}
+}>
 standard-problem-detail-entries = (
   * nint => any
 )
@@ -107,6 +107,7 @@ custom-problem-detail-entries = (
   * (uint/detail-label) => any
 )
 detail-label = text .regexp "[^:]+" / ~uri
+non-empty<M> = (M) .and ({ + any => any })
 ~~~
 {: #cddl title="Problem Detail Data Item"}
 

--- a/draft-ietf-core-problem-details.md
+++ b/draft-ietf-core-problem-details.md
@@ -181,8 +181,9 @@ SHOULD reference the present specification.
 Problem type definitions MAY extend the Problem Details document with
 additional entries to convey additional, problem-type-specific information,
 *custom problem details*.
-These receive a map key (custom problem detail entry map key, unsigned
-integer or text) and SHOULD be described in the documentation that goes
+In the definition of a problem type, each custom problem detail
+receives a map key specific to this problem type (custom problem detail entry map key, unsigned
+integer or text); this SHOULD be described in the documentation that goes
 along with the registration of a CBOR Tag for the problem type.
 
 For text detail-labels, a name without an embedded colon can be chosen


### PR DESCRIPTION
The problem-details specification has been parked for a while waiting
for CoRAL to complete.
In the meantime, 3GPP has written the problem-details specification
into their client-server specifications and is expecting to cut a
release in June 2022.
It is unlikely that the CoRAL is complete by then, which would cause
problem-details to be written out of the specification (and probably
be replaced by an ad-hoc mechanism).

This PR proposes to define a concise problem details structure that
is simple enough so it can be completed within a couple of months.
This would keep the problem details approach within the 3GPP system
and will allow us to add a more complete CoRAL version later.